### PR TITLE
Fix for properties backend which was rstripping valid values after comment markers

### DIFF
--- a/anyconfig/backend/properties.py
+++ b/anyconfig/backend/properties.py
@@ -75,10 +75,6 @@ def _pre_process_line(line, comment_markers=_COMMENT_MARKERS):
         if line.startswith(comment_markers):
             return None
 
-        for marker in comment_markers:
-            if marker in line:  # Then strip the rest starts w/ it.
-                line = line[:line.find(marker)].rstrip()
-
     return line
 
 

--- a/anyconfig/backend/properties.py
+++ b/anyconfig/backend/properties.py
@@ -66,7 +66,7 @@ def _pre_process_line(line, comment_markers=_COMMENT_MARKERS):
     >>> _pre_process_line("! " + s0) is None
     True
     >>> _pre_process_line(s0 + "# comment")
-    'calendar.japanese.type: LocalGregorianCalendar'
+    'calendar.japanese.type: LocalGregorianCalendar# comment'
     """
     if not line:
         return None
@@ -132,7 +132,7 @@ def load(stream, to_container=dict, comment_markers=_COMMENT_MARKERS):
     >>> load(to_strm(s0))
     {'calendar.japanese.type': 'LocalGregorianCalendar'}
     >>> load(to_strm(s0 + "# ..."))
-    {'calendar.japanese.type': 'LocalGregorianCalendar'}
+    {'calendar.japanese.type': 'LocalGregorianCalendar# ...'}
     >>> s1 = r"key=a\\:b"
     >>> load(to_strm(s1))
     {'key': 'a:b'}


### PR DESCRIPTION
The for loop beginning [here](https://github.com/ssato/python-anyconfig/blob/6450527e5691652ff2cafac94e9a39c6bcc087ab/anyconfig/backend/properties.py#L78) rstrips the rest of the line once it encounters # or !(comment markers) . This is invalid as per [wiki](https://en.wikipedia.org/wiki/.properties) for properties file. Any comment markers which is  in property value  is considered as part of the value itself(Refer to the `message =` key in the wiki. 

And since the line starting with # or ! (comment markers) are already removed [here](https://github.com/ssato/python-anyconfig/blob/6450527e5691652ff2cafac94e9a39c6bcc087ab/anyconfig/backend/properties.py#L75), there is no need for the for loop which makes it non-compliant with properties format.