### PR TITLE
enhancement: add support for exported shellvars

### DIFF
--- a/anyconfig/backend/shellvars.py
+++ b/anyconfig/backend/shellvars.py
@@ -47,7 +47,7 @@ def _parseline(line):
     >>> _parseline("aaa=bbb   # ccc")
     ('aaa', 'bbb')
     """
-    match = re.match(r"^\s*(\S+)=(?:(?:"
+    match = re.match(r"^\s*(export)?\s*(\S+)=(?:(?:"
                      r"(?:\"(.*[^\\])\")|(?:'(.*[^\\])')|"
                      r"(?:([^\"'#\s]+)))?)\s*#*", line)
     if not match:
@@ -55,8 +55,8 @@ def _parseline(line):
         return (None, None)
 
     tpl = match.groups()
-    vals = list(itertools.dropwhile(lambda x: x is None, tpl[1:]))
-    return (tpl[0], vals[0] if vals else '')
+    vals = list(itertools.dropwhile(lambda x: x is None, tpl[2:]))
+    return (tpl[1], vals[0] if vals else '')
 
 
 def load(stream, to_container=dict):

--- a/anyconfig/backend/tests/shellvars.py
+++ b/anyconfig/backend/tests/shellvars.py
@@ -14,8 +14,12 @@ CNF_S = """
 a=0
 b='bbb'   # a comment
 c="ccc"   # an another comment
+export d='ddd'  ## double comment
+ export e="eee" ### tripple comment
 """
-CNF = ODict((("a", "0"), ("b", "bbb"), ("c", "ccc")))
+CNF = ODict((
+    ("a", "0"), ("b", "bbb"), ("c", "ccc"), ("d", "ddd"), ("e", "eee")
+))
 
 
 class Test10(anyconfig.backend.tests.ini.Test10):


### PR DESCRIPTION
```
export foo='bar'
 export baz='xyz'
```