### PR TITLE
enhancement: allow ac_merge to be a callable for user-defined merge strategies

### DIFF
--- a/anyconfig/dicts.py
+++ b/anyconfig/dicts.py
@@ -272,7 +272,10 @@ def _get_update_fn(strategy):
     try:
         return _MERGE_FNS[strategy]
     except KeyError:
-        raise ValueError("Wrong merge strategy: %r" % strategy)
+        if callable(strategy):
+            return strategy
+        else:
+            raise ValueError("Wrong merge strategy: %r" % strategy)
 
 
 def merge(self, other, ac_merge=MS_DICTS, **options):

--- a/tests/dicts.py
+++ b/tests/dicts.py
@@ -191,4 +191,15 @@ class Test_40_merge(unittest.TestCase):
         TT.merge(dic, self.upd, ac_merge=TT.MS_DICTS_AND_LISTS)
         self.assertTrue(dicts_equal(dic, exp))
 
+    def test_50_update_with_custom_merge(self):
+        def set_none_merge_strat(self, other, key, *args, **kwargs):
+            for k in self:
+                self[k] = None
+
+        dic = copy.deepcopy(self.dic)
+        exp = dict(zip(dic.keys(), [None for _ in dic]))
+
+        TT.merge(dic, self.upd, ac_merge=set_none_merge_strat)
+        self.assertTrue(dicts_equal(dic, exp))
+
 # vim:sw=4:ts=4:et:


### PR DESCRIPTION
Allows a callable to be passed in as the `ac_merge` option to e.g. `load`. Seemed like the simplest way to allow client code to customize the merge strategy.