### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ python-anyconfig
    :target: https://pypi.python.org/pypi/anyconfig/
    :alt: [Python versions]
 
-.. .. image:: https://pypip.in/license/anyconfig/badge.png
+.. .. image:: https://img.shields.io/pypi/l/anyconfig.svg
    :target: https://pypi.python.org/pypi/anyconfig/
    :alt: MIT License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20anyconfig))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `anyconfig`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.