### PR TITLE
change: don't use ruamel.yaml if it is too old

### DIFF
--- a/anyconfig/backend/yaml/ruamel_yaml.py
+++ b/anyconfig/backend/yaml/ruamel_yaml.py
@@ -41,6 +41,8 @@ from __future__ import absolute_import
 
 import re
 import ruamel.yaml as ryaml
+if not getattr(ryaml, 'YAML', None):
+    raise ImportError('ruamel.yaml may be too old; no YAML class is defined')
 import anyconfig.utils
 
 from . import pyyaml


### PR DESCRIPTION
ruamel_yaml uses YAML class.
However, an older version of ruamel.yaml doesn't define YAML class.

https://bitbucket.org/ruamel/yaml

    0.15.0 (2017-06-04):

	    ...
	    added YAML class for new API

If an older version is installed on a system, python-anyconfig doesn't
work at all.

This change adds code verifying the existence of YAML class.

With this change, python-anyconfig chooses pyyaml as fallback yaml
parser on Fedora 28, where only version 0.13 of ruamel-yaml is
available.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>