### PR TITLE
Access containers via collections.abc if available

### DIFF
--- a/src/anyconfig/utils.py
+++ b/src/anyconfig/utils.py
@@ -13,6 +13,11 @@ import itertools
 import os.path
 import types
 
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    collections_abc = collections
+
 import anyconfig.compat
 import anyconfig.globals
 
@@ -386,7 +391,7 @@ def noop(val, *args, **kwargs):
     return val
 
 
-_LIST_LIKE_TYPES = (collections.Iterable, collections.Sequence)
+_LIST_LIKE_TYPES = (collections_abc.Iterable, collections_abc.Sequence)
 
 
 def is_dict_like(obj):


### PR DESCRIPTION
Python 3.7 warns of their removal in Python 3.8:

    >>> anyconfig.utils.collections.Iterable
    __main__:1: DeprecationWarning: Using or importing the ABCs from
    'collections' instead of from 'collections.abc' is deprecated, and
    in 3.8 it will stop working