### PR TITLE
fix deprecated collections reference

### DIFF
--- a/src/anyconfig/utils.py
+++ b/src/anyconfig/utils.py
@@ -405,7 +405,7 @@ def is_dict_like(obj):
     >>> is_dict_like(anyconfig.compat.OrderedDict((('a', 1), ('b', 2))))
     True
     """
-    return isinstance(obj, (dict, collections.Mapping))  # any others?
+    return isinstance(obj, (dict, collections_abc.Mapping))  # any others?
 
 
 def is_namedtuple(obj):


### PR DESCRIPTION
utils.py:408: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working