### PR TITLE
Change the type of anyconfig.processors.processors.Processors._processors from {str: <Pbarser_class>} to {str: <Parser_instance>}

### DIFF
--- a/src/anyconfig/backend/__init__.py
+++ b/src/anyconfig/backend/__init__.py
@@ -6,11 +6,9 @@
 # pylint: disable=wrong-import-position
 """A collection of default backend modules.
 """
-import typing
 import warnings
 
 from . import (
-    base,
     ini,
     json,
     pickle,
@@ -19,12 +17,12 @@ from . import (
     yaml,
     xml
 )
+from .base import (
+    ParserT, ParsersT, ParserClssT
+)
 
 
-ParserT = typing.TypeVar('ParserT', bound=base.Parser)
-ParsersT = typing.List[ParserT]
-
-PARSERS: ParsersT = [
+PARSERS: ParserClssT = [
     ini.Parser, pickle.Parser, properties.Parser, shellvars.Parser, xml.Parser
 ] + json.PARSERS
 
@@ -40,5 +38,11 @@ try:
     PARSERS.append(toml.Parser)
 except ImportError:
     warnings.warn(_NA_MSG.format('toml', 'TOML'), ImportWarning)
+
+
+__all__ = [
+    'ParserT', 'ParsersT', 'ParserClssT',
+    'PARSERS',
+]
 
 # vim:sw=4:ts=4:et:

--- a/src/anyconfig/backend/base/__init__.py
+++ b/src/anyconfig/backend/base/__init__.py
@@ -26,6 +26,8 @@ from .parsers import (
 
 ParserT = typing.TypeVar('ParserT', bound=Parser)
 ParsersT = typing.List[ParserT]
+ParserClssT = typing.List[typing.Type[ParserT]]
+
 
 __all__ = [
     'ToStringDumperMixin', 'ToStreamDumperMixin',
@@ -34,7 +36,7 @@ __all__ = [
     'ensure_outdir_exists', 'to_method',
     'Parser',
     'StringParser', 'StreamParser', 'StringStreamFnParser',
-    'ParserT', 'ParsersT',
+    'ParserT', 'ParsersT', 'ParserClssT',
 ]
 
 # vim:sw=4:ts=4:et:

--- a/src/anyconfig/backend/json/__init__.py
+++ b/src/anyconfig/backend/json/__init__.py
@@ -14,11 +14,11 @@ Changelog:
    - Started to split JSON support modules
 """
 from . import default
-from ..base import ParsersT
+from ..base import ParserClssT
 
 
 Parser = default.Parser  # To keep backward compatibility.
-PARSERS: ParsersT = [Parser]
+PARSERS: ParserClssT = [Parser]
 
 try:
     from .simplejson import Parser as SimpleJsonParser

--- a/src/anyconfig/backend/yaml/__init__.py
+++ b/src/anyconfig/backend/yaml/__init__.py
@@ -14,14 +14,14 @@ Changelog:
    - Split PyYaml-based and ruamel.yaml based backend modules
    - Add support of some of ruamel.yaml specific features.
 """
-from ..base import ParsersT
+from ..base import ParserClssT
 
 
 try:
     from . import pyyaml
-    PARSERS: ParsersT = [pyyaml.Parser]
+    PARSERS: ParserClssT = [pyyaml.Parser]
 except ImportError:
-    PARSERS: ParsersT = []  # type: ignore
+    PARSERS: ParserClssT = []  # type: ignore
 
 try:
     from . import ruamel_yaml as ryaml

--- a/src/anyconfig/parsers/parsers.py
+++ b/src/anyconfig/parsers/parsers.py
@@ -8,7 +8,7 @@
 """
 import typing
 
-from ..backend import ParsersT, PARSERS
+from ..backend import ParserClssT, PARSERS
 from ..processors import Processors
 from ..singleton import Singleton
 
@@ -19,7 +19,7 @@ class Parsers(Processors, Singleton):
     """
     _pgroup: str = 'anyconfig_backends'
 
-    def __init__(self, prcs: typing.Optional[ParsersT] = None
+    def __init__(self, prcs: typing.Optional[ParserClssT] = None
                  ) -> None:
         """Initialize with PARSERS.
         """

--- a/src/anyconfig/parsers/utils.py
+++ b/src/anyconfig/parsers/utils.py
@@ -12,7 +12,6 @@ from ..backend import ParserT, ParsersT
 from .parsers import Parsers
 
 
-ParserClssT = typing.List[typing.Type[ParserT]]
 MaybeParserT = typing.Optional[
     typing.Union[str, ParserT, typing.Type[ParserT]]
 ]
@@ -30,30 +29,30 @@ def list_types() -> typing.List[str]:
     return sorted(Parsers().list_x('type'))
 
 
-def list_by_cid() -> typing.List[typing.Tuple[str, ParserClssT]]:
+def list_by_cid() -> typing.List[typing.Tuple[str, ParsersT]]:
     """
-    List processors by each cid, [(cid, [Parser_class])].
+    List processors by each cid.
     """
     return Parsers().list_by_x('cid')
 
 
-def list_by_type() -> typing.List[typing.Tuple[str, ParserClssT]]:
+def list_by_type() -> typing.List[typing.Tuple[str, ParsersT]]:
     """
-    List processor by eacch type, [(type, [Parser_class])].
+    List processor by eacch type.
     """
     return Parsers().list_by_x('type')
 
 
-def list_by_extension() -> typing.List[typing.Tuple[str, ParserClssT]]:
+def list_by_extension() -> typing.List[typing.Tuple[str, ParsersT]]:
     """
-    List processor by file extension supported, [(extension, [Parser_class])].
+    List processor by file extension supported.
     """
     return Parsers().list_by_x('extensions')
 
 
 def findall(obj: typing.Optional[PathOrIOInfoT] = None,
             forced_type: typing.Optional[str] = None
-            ) -> ParsersT:
+            ) -> typing.List[ParserT]:
     """
     Find out processor objects can process data from given 'obj' which may be a
     file path, file or file-like object, pathlib.Path object or an

--- a/src/anyconfig/processors/datatypes.py
+++ b/src/anyconfig/processors/datatypes.py
@@ -10,6 +10,7 @@ from ..models import processor
 
 
 ProcT = typing.TypeVar('ProcT', bound=processor.Processor)
+ProcsT = typing.List[ProcT]
 ProcClsT = typing.Type[ProcT]
 ProcClssT = typing.List[ProcClsT]
 

--- a/src/anyconfig/processors/utils.py
+++ b/src/anyconfig/processors/utils.py
@@ -18,11 +18,11 @@ from ..ioinfo import make as ioinfo_make
 from ..models import processor
 from ..utils import concat, groupby
 from .datatypes import (
-    ProcT, ProcClsT, ProcClssT, MaybeProcT
+    ProcT, ProcsT, ProcClsT, MaybeProcT
 )
 
 
-def sort_by_prio(prs: typing.Iterable[ProcClsT]) -> ProcClssT:
+def sort_by_prio(prs: typing.Iterable[ProcT]) -> ProcsT:
     """
     Sort an iterable of processor classes by each priority.
 
@@ -49,8 +49,8 @@ def select_by_key(items: typing.Iterable[
                 for k, g in groupby(itr, operator.itemgetter(0)))
 
 
-def list_by_x(prs: typing.Iterable[ProcClsT], key: str
-              ) -> typing.List[typing.Tuple[str, ProcClssT]]:
+def list_by_x(prs: typing.Iterable[ProcT], key: str
+              ) -> typing.List[typing.Tuple[str, ProcsT]]:
     """
     :param key: Grouping key, 'type' or 'extensions'
     :return:
@@ -65,7 +65,7 @@ def list_by_x(prs: typing.Iterable[ProcClsT], key: str
 
     elif key == 'extensions':
         res: typing.List[  # type: ignore
-            typing.Tuple[str, ProcClssT]
+            typing.Tuple[str, ProcsT]
         ] = select_by_key(((p.extensions(), p) for p in prs),
                           sort_fn=sort_by_prio)
     else:
@@ -77,7 +77,7 @@ def list_by_x(prs: typing.Iterable[ProcClsT], key: str
 
 
 def findall_with_pred(predicate: typing.Callable[..., bool],
-                      prs: ProcClssT) -> ProcClssT:
+                      prs: ProcsT) -> ProcsT:
     """
     :param predicate: any callable to filter results
     :param prs: A list of :class:`anyconfig.models.processor.Processor` classes
@@ -110,7 +110,7 @@ def maybe_processor(type_or_id: typing.Union[ProcT, ProcClsT],
     return None
 
 
-def find_by_type_or_id(type_or_id: str, prs: ProcClssT) -> ProcClssT:
+def find_by_type_or_id(type_or_id: str, prs: ProcsT) -> ProcsT:
     """
     :param type_or_id: Type of the data to process or ID of the processor class
     :param prs: A list of :class:`anyconfig.models.processor.Processor` classes
@@ -130,7 +130,7 @@ def find_by_type_or_id(type_or_id: str, prs: ProcClssT) -> ProcClssT:
     return pclss
 
 
-def find_by_fileext(fileext: str, prs: ProcClssT) -> ProcClssT:
+def find_by_fileext(fileext: str, prs: ProcsT) -> ProcsT:
     """
     :param fileext: File extension
     :param prs: A list of :class:`anyconfig.models.processor.Processor` classes
@@ -148,7 +148,7 @@ def find_by_fileext(fileext: str, prs: ProcClssT) -> ProcClssT:
     return pclss  # :: [Processor], never []
 
 
-def find_by_maybe_file(obj: PathOrIOInfoT, prs: ProcClssT) -> ProcClssT:
+def find_by_maybe_file(obj: PathOrIOInfoT, prs: ProcsT) -> ProcsT:
     """
     :param obj:
         a file path, file or file-like object, pathlib.Path object or an
@@ -163,9 +163,9 @@ def find_by_maybe_file(obj: PathOrIOInfoT, prs: ProcClssT) -> ProcClssT:
     return find_by_fileext(obj.extension, prs)  # :: [Processor], never []
 
 
-def findall(obj: typing.Optional[PathOrIOInfoT], prs: ProcClssT,
+def findall(obj: typing.Optional[PathOrIOInfoT], prs: ProcsT,
             forced_type: typing.Optional[str] = None,
-            ) -> ProcClssT:
+            ) -> ProcsT:
     """
     :param obj:
         a file path, file, file-like object, pathlib.Path object or an
@@ -195,7 +195,7 @@ def findall(obj: typing.Optional[PathOrIOInfoT], prs: ProcClssT,
     return pclss
 
 
-def find(obj: typing.Optional[PathOrIOInfoT], prs: ProcClssT,
+def find(obj: typing.Optional[PathOrIOInfoT], prs: ProcsT,
          forced_type: MaybeProcT = None,
          ) -> ProcT:
     """
@@ -224,8 +224,8 @@ def find(obj: typing.Optional[PathOrIOInfoT], prs: ProcClssT,
 
         return proc
 
-    pclss = findall(obj, prs, forced_type=typing.cast(str, forced_type))
-    return pclss[0]()
+    procs = findall(obj, prs, forced_type=typing.cast(str, forced_type))
+    return procs[0]
 
 
 def load_plugins(pgroup: str) -> typing.Iterator[ProcClsT]:


### PR DESCRIPTION
Changed the type of anyconfig.processors.processors.Processors._processors from typing.Dict[str, <Processor_class>] to typing.Dict[str, <Processor_instance>] to simplify methods and functions process it.
