### PR TITLE
fix: re-enable output type guessing from output file name

### DIFF
--- a/src/anyconfig/cli.py
+++ b/src/anyconfig/cli.py
@@ -197,6 +197,7 @@ def _parse_args(argv):
             _show_psrs()
         elif args.env:
             cnf = os.environ.copy()
+            args.otype = args.otype or "json"
             _output_result(cnf, args)
             sys.exit(0)
         else:
@@ -280,7 +281,7 @@ def _output_result(cnf, args, inpaths=None, extra_opts=None):
     """
     fmsg = ("Uknown file type and cannot detect appropriate backend "
             "from its extension, '%s'")
-    (outpath, otype) = (args.output, args.otype or "json")
+    (outpath, otype) = (args.output, args.otype)
 
     if not utils.is_dict_like(cnf):
         _exit_with_output(str(cnf))  # Print primitive types as it is.

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -302,12 +302,20 @@ class Test_50_others_w_input(Test_20_Base):
 
     def setUp(self):
         super().setUp()
-        dic = dict(name="a", a=1, b=dict(b=[1, 2], c="C"), d=[1, 2])
+        self.dic = dict(name="a", a=1, b=dict(b=[1, 2], c="C"), d=[1, 2])
         self.infile = self.workdir / "a.json"
-        anyconfig.api.dump(dic, self.infile)
+        anyconfig.api.dump(self.dic, self.infile)
 
     def test_10_output_wo_output_option_w_otype(self):
         self.run_and_check_exit_code(["--otype", "json", self.infile])
+
+    def test_11_output_w_output_option_wo_otype(self):
+        outfile = self.workdir / "out.yml"
+        _run("-o", outfile, self.infile)
+        self.assertTrue(outfile.exists())
+        ref = self.workdir / "a.yml"
+        anyconfig.api.dump(self.dic, ref)
+        self.assertEqual(outfile.read_text(), ref.read_text())
 
     def test_12_output_wo_output_option_and_otype_w_itype(self):
         self.run_and_check_exit_code(["--itype", "json", self.infile])


### PR DESCRIPTION
The refactoring done in a4a53ab900045b023777b06c160ea43197fe24d3
introduced unexpected side-effect. With the commit anyconfig lost the
function to guess the output type from the output file name:

    $ cat foo.json
    {"a": 1}
    $ anyconfig_cli -o foo.yml foo.json
    $ cat foo.yml
    cat foo.yml
    {"a": 1}$

anyconfig_cli emits JSON output though YAML output guessed from
'foo.yml' is execpted,

Signed-off-by: Masatake YAMATO <yamato@redhat.com>