### PR TITLE
Fix "error: unbalanced parenthesis at position 15"

### DIFF
--- a/src/anyconfig/ioinfo/constants.py
+++ b/src/anyconfig/ioinfo/constants.py
@@ -16,7 +16,7 @@ PATH_SEP: str = os.path.sep
 SPLIT_PATH_RE: typing.Pattern = re.compile(
     fr'([^{GLOB_MARKER}]+)'
     fr'{PATH_SEP}'
-    fr'(.*\{GLOB_MARKER}.*)'
+    fr'(.*{GLOB_MARKER}.*)'
 )
 
 # vim:sw=4:ts=4:et:

--- a/src/anyconfig/ioinfo/constants.py
+++ b/src/anyconfig/ioinfo/constants.py
@@ -14,9 +14,9 @@ GLOB_MARKER: str = '*'
 PATH_SEP: str = os.path.sep
 
 SPLIT_PATH_RE: typing.Pattern = re.compile(
-    fr'([^{GLOB_MARKER}]+)'
-    fr'{PATH_SEP}'
-    fr'(.*{GLOB_MARKER}.*)'
+    fr'([^{re.escape(GLOB_MARKER)}]+)'
+    fr'{re.escape(PATH_SEP)}'
+    fr'(.*{re.escape(GLOB_MARKER)}.*)'
 )
 
 # vim:sw=4:ts=4:et:


### PR DESCRIPTION
When I do `import anyconfig` using v0.11.1 and Python 3.9.7 on **Windows**, I get the following. I think this PR fixes it.

Although, TBH, I don't think it's a good idea to parse file names using regular expressions. You're better off with [pathlib](https://docs.python.org/3/library/pathlib.html), in my experience. Regardless, there's an issue with `split_path_by_marker` that, if `split_re` needs to be updated based on `marker` and `path_sep`, i.e. they're not independent inputs.

<details>

```
...

<venv>\lib\site-packages\anyconfig\ioinfo\utils.py in <module>
      8 import typing
      9 
---> 10 from .constants import (
     11     GLOB_MARKER, PATH_SEP, SPLIT_PATH_RE
     12 )

<venv>\lib\site-packages\anyconfig\ioinfo\constants.py in <module>
     14 PATH_SEP: str = os.path.sep
     15 
---> 16 SPLIT_PATH_RE: typing.Pattern = re.compile(
     17     fr'([^{GLOB_MARKER}]+)'
     18     fr'{PATH_SEP}'

<venv>\lib\re.py in compile(pattern, flags)
    250 def compile(pattern, flags=0):
    251     "Compile a regular expression pattern, returning a Pattern object."
--> 252     return _compile(pattern, flags)
    253 
    254 def purge():

<venv>\lib\re.py in _compile(pattern, flags)
    302     if not sre_compile.isstring(pattern):
    303         raise TypeError("first argument must be string or compiled pattern")
--> 304     p = sre_compile.compile(pattern, flags)
    305     if not (flags & DEBUG):
    306         if len(_cache) >= _MAXCACHE:

<venv>\lib\sre_compile.py in compile(p, flags)
    762     if isstring(p):
    763         pattern = p
--> 764         p = sre_parse.parse(p, flags)
    765     else:
    766         pattern = None

<venv>\lib\sre_parse.py in parse(str, flags, state)
    960     if source.next is not None:
    961         assert source.next == ")"
--> 962         raise source.error("unbalanced parenthesis")
    963 
    964     if flags & SRE_FLAG_DEBUG:

error: unbalanced parenthesis at position 15
```

</details>