### PR TITLE
fix: add a packaging configuration to distribute type hints data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,9 @@ install_requires =
 # share/man/man1 =
 #         docs/anyconfig_cli.1
 
+[options.package_data]
+anyconfig = py.typed
+
 [options.extras_require]
 yaml =
     pyyaml


### PR DESCRIPTION
A couple of changes to provide type hints data.

It may close #141.