### PR TITLE
enhancement: use ruff to check code styles

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -24,3 +24,5 @@ pylint
 pytest
 pytest-cov
 pytest-randomly
+# see: https://notes.crmarsh.com/python-tooling-could-be-much-much-faster
+ruff

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -24,5 +24,6 @@ pylint
 pytest
 pytest-cov
 pytest-randomly
+# Disable until 'pip install' failures happen in CI env.
 # see: https://notes.crmarsh.com/python-tooling-could-be-much-much-faster
-ruff
+#ruff

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ exclude = .git,.tox,dist,*egg,setup.py
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/tests/requirements.txt
+    lint: ruff
 commands =
     pytest
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ setenv =
 commands =
     flake8 --doctests src tests
     - pylint --disable=invalid-name,locally-disabled --init-hook 'import os,sys; sys.path.insert(0, os.curdir)' src
+    ruff -v src tests
 
 [testenv:type-check]
 deps =


### PR DESCRIPTION
Changes to use ruff to check code styles more quickly.

- ruff is very fast
- ruff is written in rust but easy to install using pip

seealso: https://notes.crmarsh.com/python-tooling-could-be-much-much-faster
