### PR TITLE
Enable codecov statics report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,5 +36,12 @@ jobs:
         run: tox
         env:
           PLATFORM: ${{ matrix.platform }}
-
-# vim:sw=2:ts=2:et:
+      - uses: codecov/codecov-action@v3
+        # .. seealso:: https://github.com/marketplace/actions/codecov#usage
+        with:
+          # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          # files: ./coverage1.xml,./coverage2.xml # optional
+          # flags: unittests # optional
+          # name: codecov-umbrella # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,4 +108,4 @@ python_files =
     test_*.py
     Test*.py
 
-addopts = --cov=src -vv
+addopts = --cov=src -vv --cov --cov-report xml


### PR DESCRIPTION
Enable codecov to watch its statistics and try keeping high level of test coverage.