### PR TITLE
change: switch to importlib.metadata from pkg_resources in setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,10 +56,6 @@ packages = find:
 package_dir =
         = src
 
-# minimum dependencies.
-install_requires =
-    setuptools
-
 # Disabled because it does not work in CentOS 8.
 # [options.data_files]
 # share/man/man1 =

--- a/src/anyconfig/processors/utils.py
+++ b/src/anyconfig/processors/utils.py
@@ -11,7 +11,7 @@ import operator
 import typing
 import warnings
 
-import pkg_resources
+import importlib.metadata
 
 from .. import common, ioinfo, models, utils
 from .datatypes import (
@@ -241,7 +241,9 @@ def load_plugins(pgroup: str) -> typing.Iterator[ProcClsT]:
 
     :param pgroup: A string represents plugin type, e.g. anyconfig_backends
     """
-    for res in pkg_resources.iter_entry_points(pgroup):
+    eps = importlib.metadata.entry_points()
+    for res in (eps.get(pgroup, []) if isinstance(eps, dict)
+                else eps.select(group=pgroup)):
         try:
             yield res.load()
         except ImportError as exc:


### PR DESCRIPTION
Switch to importlib.metadata from pkg_resources in setuptools to load plugins modules with pkg_resources.iter_entry_points because pkg_resources is deprecated.

.. seealso:: https://importlib-metadata.readthedocs.io/en/latest/migration.html#pkg-resources-iter-entry-points