### PR TITLE
change: remove inheritance from BinaryLoaderrMixin and BinaryDumperMixin

### DIFF
--- a/src/anyconfig/backend/pickle/stdlib.py
+++ b/src/anyconfig/backend/pickle/stdlib.py
@@ -36,13 +36,14 @@ LOAD_OPTS = ['fix_imports', 'encoding', 'errors']
 DUMP_OPTS = ['protocol', 'fix_imports']
 
 
-class Parser(base.StringStreamFnParser,
-             base.BinaryLoaderMixin, base.BinaryDumperMixin):
+class Parser(base.StringStreamFnParser):
     """Parser for Pickle files."""
-
     _cid = 'pickle.stdlib'
     _type = 'pickle'
     _extensions = ['pkl', 'pickle']
+    _open_read_mode: str = 'rb'
+    _open_write_mode: str = 'wb'
+
     _load_opts = LOAD_OPTS
     _dump_opts = DUMP_OPTS
     _allow_primitives = True
@@ -51,5 +52,3 @@ class Parser(base.StringStreamFnParser,
     _load_from_stream_fn = base.to_method(pickle.load)
     _dump_to_string_fn = base.to_method(pickle.dumps)
     _dump_to_stream_fn = base.to_method(pickle.dump)
-
-# vim:sw=4:ts=4:et:

--- a/src/anyconfig/backend/toml/tomllib.py
+++ b/src/anyconfig/backend/toml/tomllib.py
@@ -30,10 +30,7 @@ import tomli_w
 from .. import base
 
 
-class Parser(
-    base.StringStreamFnParser,
-    base.BinaryLoaderMixin, base.BinaryDumperMixin
-):
+class Parser(base.StringStreamFnParser):
     """TOML parser using tomlib and tomli-w."""
 
     _cid = 'toml.tomllib'
@@ -41,6 +38,8 @@ class Parser(
     _extensions = ['toml']
     _ordered = True
     _load_opts = ['parse_float']
+    _open_read_mode: str = 'rb'
+    _open_write_mode: str = 'wb'
 
     _load_from_string_fn = base.to_method(tomllib.loads)
     _load_from_stream_fn = base.to_method(tomllib.load)

--- a/src/anyconfig/backend/xml/etree.py
+++ b/src/anyconfig/backend/xml/etree.py
@@ -466,8 +466,7 @@ def etree_write(tree, stream):
         tree.write(stream, encoding='unicode', xml_declaration=True)
 
 
-class Parser(base.Parser, base.ToStreamDumperMixin,
-             base.BinaryDumperMixin, base.BinaryLoaderMixin):
+class Parser(base.Parser, base.ToStreamDumperMixin):
     """Parser for XML files."""
 
     _cid = 'xml.etree'
@@ -476,6 +475,8 @@ class Parser(base.Parser, base.ToStreamDumperMixin,
     _load_opts = _dump_opts = ['tags', 'merge_attrs', 'ac_parse_value']
     _ordered = True
     _dict_opts = ['ac_dict']
+    _open_read_mode: str = 'rb'
+    _open_write_mode: str = 'wb'
 
     def load_from_string(self, content, container, **opts):
         """Load config from XML snippet (a string 'content').


### PR DESCRIPTION
Remove inheritance from
anyconfig.backend.base.Binary{Loader,Dumper}Mixin to reduce parent classes and simplify the inheritance hierarchy..