### PR TITLE
Migrate from setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,133 @@
+# .. seealso:: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
+[project]
+name = "anyconfig"
+dynamic = [
+    "version",
+]
+description = "Library provides common APIs to load and dump configuration files in various formats"
+readme = "README.rst"
+authors = [
+    {"name" = "Satoru SATOH", email = "satoru.satoh@gmail.com"},
+]
+maintainers = [
+    {"name" = "Satoru SATOH", email = "satoru.satoh@gmail.com"},
+]
+license = { text = "MIT"}
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Environment :: Console",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Text Processing :: Markup",
+    "Topic :: Utilities",
+    "License :: OSI Approved :: MIT License",
+]
+# .. note:: It requires nothing at minimum.
+#dependencies = [
+#]
+
+[project.urls]
+Homepage = "https://github.com/ssato/python-anyconfig"
+Documentation = "http://python-anyconfig.readthedocs.org"
+Repository = "https://github.com/ssato/python-anyconfig"
+Issues = "https://github.com/ssato/python-anyconfig/issues"
+Changelog = "https://github.com/ssato/python-anyconfig/blob/next/NEWS"
+Download = "https://pypi.python.org/pypi/anyconfig"
+"Download RPMs" = "https://copr.fedoraproject.org/coprs/ssato/python-anyconfig/"
+CI = "https://github.com/ssato/python-anyconfig/actions"
+
+[build-system]
+requires = [
+    "setuptools >= 61.0",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.package-data]
+anyconfig = [
+    "py.typed",
+]
+
+[tool.setuptools.packages.find]
+where = [
+    "src"
+]
+
+[project.optional-dependencies]
+yaml = [
+    "pyyaml",
+]
+toml = [
+    "tomli; python_version < '3.11'",
+    "tomli-w",
+]
+query = [
+    "jmespath",
+]
+schema = [
+    "jsonschema",
+]
+template = [
+    "Jinja2",
+]
+
+[project.scripts]
+anyconfig_cli = "anyconfig.cli:main"
+
+# .. seealso:: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]
+addopts = "--cov=src -vv -rxXs --cov --cov-report xml"
+
+# .. note::
+# 
+#    The following options are not supported by pyproject.toml or I don't know
+#    how to port from setup.cfg.
+#
+#
+# [meta]
+# long_description =
+#     python-anyconfig is a python library provides common APIs to load and dump
+#     configuration files in various formats with some useful features such as
+#     contents merge, templates, query, schema validation and generation support.
+# 
+#     - Home: https://github.com/ssato/python-anyconfig
+#     - Author: Satoru SATOH <satoru.satoh@gmail.com>
+#     - License: MIT
+
+#[aliases]
+# dists = clean --all sdist bdist_wheel
+
+# .. note:: It's not well supported.
+# .. seealso:: https://github.com/pypa/packaging-problems/issues/72
+#
+# Disabled because it does not work in CentOS 8.
+# [options.data_files]
+# share/man/man1 =
+#         docs/anyconfig_cli.1
+
+# .. seealso:: https://stackoverflow.com/a/64487610
+#
+# flake8]
+# per-file-ignores =
+#     tests/res/*/*/*/*.py: W605, B018
+#     tests/res/*/*/*/*/*.py: W605, B018
+# 
+# max-complexity = 10
+# select = C,E,F,W,B
+# 
+# # .. seealso:: https://www.flake8rules.com/rules/W504.html
+# ignore = W503

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ classifiers = [
 #dependencies = [
 #]
 
+[tool.setuptools.dynamic.version]
+attr = "anyconfig.api.__version__"
+
 [project.urls]
 Homepage = "https://github.com/ssato/python-anyconfig"
 Documentation = "http://python-anyconfig.readthedocs.org"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--r requirements_min.txt
 Jinja2
 PyYAML
 jmespath

--- a/requirements_min.txt
+++ b/requirements_min.txt
@@ -1,1 +1,0 @@
-setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,91 +1,7 @@
 # .. seealso:: https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 
-# .. seealso:: https://wheel.readthedocs.io/en/stable/
-[bdist_wheel]
-universal = 1
-
 [aliases]
 dists = clean --all sdist bdist_wheel
-
-[metadata]
-name = anyconfig
-#version = attr: anyconfig.__version__
-description = Library provides common APIs to load and dump configuration files in various formats
-project_urls =
-    CI: Github Actions = https://github.com/ssato/python-anyconfig/actions
-    Download = https://pypi.python.org/pypi/anyconfig
-    Download RPMs = https://copr.fedoraproject.org/coprs/ssato/python-anyconfig/
-    Documentation = http://python-anyconfig.readthedocs.org
-    Bug Tracker = https://github.com/ssato/python-anyconfig/issues
-    Source = https://github.com/ssato/python-anyconfig
-long_description =
-    python-anyconfig is a python library provides common APIs to load and dump
-    configuration files in various formats with some useful features such as
-    contents merge, templates, query, schema validation and generation support.
-
-    - Home: https://github.com/ssato/python-anyconfig
-    - Author: Satoru SATOH <satoru.satoh@gmail.com>
-    - License: MIT
-
-author = Satoru SATOH
-author_email = satoru.satoh@gmail.com
-maintainer = Satoru SATOH
-maintainer_email = satoru.satoh@gmail.com
-license = MIT
-url = https://github.com/ssato/python-anyconfig
-classifiers =
-    Development Status :: 4 - Beta
-    Intended Audience :: Developers
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Environment :: Console
-    Operating System :: OS Independent
-    Topic :: Software Development :: Libraries :: Python Modules
-    Topic :: Text Processing :: Markup
-    Topic :: Utilities
-    License :: OSI Approved :: MIT License
-
-[options]
-include_package_data = True
-packages = find:
-package_dir =
-        = src
-
-# Disabled because it does not work in CentOS 8.
-# [options.data_files]
-# share/man/man1 =
-#         docs/anyconfig_cli.1
-
-[options.package_data]
-anyconfig = py.typed
-
-[options.extras_require]
-yaml =
-    pyyaml
-toml =
-    tomli; python_version < "3.11"
-    tomli-w
-query =
-    jmespath
-schema =
-    jsonschema
-template =
-    Jinja2
-
-[options.packages.find]
-where = src
-exclude =
-    tests
-    tests.*
-
-[options.entry_points]
-console_scripts =
-    anyconfig_cli = anyconfig.cli:main
 
 [flake8]
 per-file-ignores =
@@ -97,13 +13,3 @@ select = C,E,F,W,B
 
 # .. seealso:: https://www.flake8rules.com/rules/W504.html
 ignore = W503
-
-[tool:pytest]
-testpaths =
-    tests
-
-python_files =
-    test_*.py
-    Test*.py
-
-addopts = --cov=src -vv -rxXs --cov --cov-report xml

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,6 @@ deps =
 [testenv:doc]
 allowlist_externals =
     make
-
 deps =
     {[testenv]deps}
     -r{toxinidir}/docs/requirements.txt


### PR DESCRIPTION
Start migration from setup.cfg and setup.py to pyproject.toml to modernize its packaging stuff.