### PR TITLE
Fix rpm stuff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ jobs:
         platform:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
           # - macos-latest
         python-version:
           - 3.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
         platform:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
           # - macos-latest
         python-version:
           - 3.9

--- a/pkg/buildsrpm.sh
+++ b/pkg/buildsrpm.sh
@@ -1,0 +1,90 @@
+#! /bin/bash
+#
+# Build source RPM from source and RPM SPEC file.
+#
+set -e -o pipefail
+
+usage="Usage: $0 [NAME [RPMSPECIN [BUILDDIR [SRCDIR]]]]"
+
+self=$0
+selfdir="${self%/*}"
+
+RPMSPECIN="${selfdir:?}/package.spec.in"
+
+BUILDDIR="${selfdir}/../build"
+SRCDIR="${selfdir}/../src"
+DISTDIR="${selfdir}/../dist"
+
+# Set or detect name.
+NAME=${1}
+[[ -z ${NAME} ]] && {
+    NAME=$(sed -nr 's/^name.*=.*"(\S+)"$/\1/p' pyproject.toml)
+    [[ -z ${NAME} ]] && {
+        cat << EOM
+[Error] No name was provided, and could not be automatically detected.
+EOM
+        echo "${usage}"
+        exit 1
+    } || :
+}
+
+RPMSPECIN=${2:-${RPMSPECIN}}
+BUILDDIR=${3:-${BUILDDIR}}
+SRCDIR=${4:-${SRCDIR}}
+RELEASE=${5:-1}
+
+test -f ${RPMSPECIN:?} && test -d ${SRCDIR:?} && test -d ${DISTDIR:?} || {
+    echo "[Error] NOT found: ${RPMSPECIN} and/or ${SRCDIR} and/or ${DISTDIR}"
+    echo "${usage}"
+    exit 1
+}
+
+test -d ${BUILDDIR} || mkdir -p ${BUILDDIR}
+
+# Detect version info.
+candidates=$(
+find ${SRCDIR} -type f -iregex '.*/__init__.py'
+)
+
+for f in ${candidates:?}
+do
+  VERSION=$(
+    grep -q __version__ $f &&
+    sed -nr 's/^__version__ = .(.+)./\1/p' $f || :
+)
+  [[ -z ${VERSION} ]] || break
+done
+
+[[ -z ${VERSION} ]] && {
+    cat << EOM
+[Error] Could NOT find version string from ${SRCDIR}/**/__init__.py
+EOM
+    exit 1
+} || :
+
+# Find src dist.
+SRCDIST=$(ls -1 ${DISTDIR}/${NAME}-${VERSION}.*)
+[[ -z ${SRCDIST} ]] && {
+    echo "[Error] Cound NOT find src dist. Build it in advance."
+} || :
+cp -f ${SRCDIST} ${BUILDDIR}
+
+# Generate the RPM SPEC file from ${RPMSPECIN}.
+RPMSPECIN_fn=${RPMSPECIN##*/}
+RPMSPEC=${BUILDDIR}/${RPMSPECIN_fn/.in/}
+
+sed -r "
+s/@NAME@/${NAME}/g
+s/@VERSION@/${VERSION}/g
+s/@RELEASE@/${RELEASE}/g
+" ${RPMSPECIN} > ${RPMSPEC}
+
+_rpmbuild () {
+    rpmbuild --define "_topdir ${BUILDDIR}" \
+        --define "_srcrpmdir ${BUILDDIR}" \
+        --define "_sourcedir ${BUILDDIR}" \
+        --define "_buildroot ${BUILDDIR}" \
+        -bs $@
+}
+
+_rpmbuild ${RPMSPEC}

--- a/pkg/package.spec.in
+++ b/pkg/package.spec.in
@@ -16,7 +16,8 @@ Release:        @RELEASE@
 Summary:        Python library to load and dump configuration files in various formats
 License:        MIT
 URL:            https://github.com/ssato/python-anyconfig
-Source0:        %{url}/archive/RELEASE_%{version}.tar.gz
+# Source0:        %%{url}/archive/RELEASE_%%{version}.tar.gz
+Source0:        %{pkgname}-%{version}.tar.gz
 BuildArch:      noarch
 
 %if %{with doc}
@@ -60,6 +61,9 @@ HTML documentation for %{name}.
 %autosetup -n %{pkgname}-%{version}
 
 %build
+# hack: To avoid build-time error with the later license identifier format in
+# pyproject.toml since PEP 639.
+sed -i.save -r '/^license = /,/^]/s/^.*/# &/g' pyproject.toml
 %py3_build
 
 %if %{with doc}
@@ -90,6 +94,10 @@ tox -e py$(python -c "import sys; sys.stdout.write(sys.version[:3].replace('.', 
 %endif
 
 %changelog
+* Mon Feb 16 2026 Satoru SATOH <ssato@redhat.com> - 0.15.0-1
+- new upstream release
+- see NEWS fore more details
+
 * Mon Jan 15 2024 Satoru SATOH <ssato@redhat.com> - 0.14.0-1
 - new upstream release
 - see NEWS fore more details

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,11 @@ import os
 import pathlib
 import re
 import setuptools
-import setuptools.command.bdist_rpm
 
 
 # It might throw IndexError and so on.
-VERSION = "0.1.0"
-VER_REG = re.compile(r"^__version__ = '([^']+)'")
+VERSION = os.getenv("_PKG_VERSION", default="0.1.0")
+VER_REG = re.compile(r"^__version__ = \"([^']+)\"")
 
 for fpath in pathlib.Path("src").glob("**/__init__.py"):
     for line in fpath.open():
@@ -17,42 +16,7 @@ for fpath in pathlib.Path("src").glob("**/__init__.py"):
             VERSION = match.groups()[0]
             break
 
-# For daily snapshot versioning mode:
-RELEASE = "1%{?dist}"
-if os.environ.get("_SNAPSHOT_BUILD", None) is not None:
-    import datetime
-    RELEASE = RELEASE.replace(
-        "1",
-        datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y%m%d"),
-    )
-
-
-def _replace(line: str) -> str:
-    """Replace some strings in the RPM SPEC template."""
-    if "@VERSION@" in line:
-        return line.replace("@VERSION@", VERSION)
-
-    if "@RELEASE@" in line:
-        return line.replace("@RELEASE@", RELEASE)
-
-    if "Source0:" in line:  # Dirty hack
-        return "Source0: %{pkgname}-%{version}.tar.gz"
-
-    return line
-
-
-class bdist_rpm(setuptools.command.bdist_rpm.bdist_rpm):  # noqa: N801
-    """Override the default content of the RPM SPEC."""
-
-    spec_tmpl = pathlib.Path("pkg/package.spec.in").resolve()
-
-    def _make_spec_file(self) -> list[str]:
-        """Generate the RPM SPEC file."""
-        return [_replace(line.rstrip()) for line in self.spec_tmpl.open()]
-
-
 setuptools.setup(
     version=VERSION,
-    cmdclass={"bdist_rpm": bdist_rpm},
     data_files=[("share/man/man1", ["docs/anyconfig_cli.1"])],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -97,8 +97,8 @@ commands =
 [testenv:srpm]
 passenv =
     _SNAPSHOT_BUILD
+deps =
+    {[testenv:sdist]deps}
 commands =
     {[testenv:sdist]commands}
     python setup.py bdist_rpm --source-only --dist-dir {toxinidir}/dist
-
-# vim:sw=4:ts=4:et:


### PR DESCRIPTION
Fix and enhance rpm related stuff to follow the changes in the latest tools like setuptools, and build them correctly.

- enhancement: add a script to build SRPM fom src dist and pkg/package.spec.in
- fix: remove rpm related hack as bdist_rpm was deprecated in the latest setuptools
- fix: [tox] add missing dependencies in srpm target
- fix: [rpm] add hack to avoid false-positive errors in pyproject.toml